### PR TITLE
Adds make

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,8 @@ RUN apk add \
             texmf-dist \
             ghostscript \
             librsvg \
-            ttf-dejavu && \
+            ttf-dejavu \
+            make && \
     rm -rf /var/cache/apk/* && \
     wget -P /tmp https://github.com/jgm/pandoc/releases/download/${PANDOC_VERSION}/pandoc-${PANDOC_VERSION}-linux.tar.gz && \
     tar -xf /tmp/pandoc-${PANDOC_VERSION}-linux.tar.gz -C /tmp && \


### PR DESCRIPTION
make is pretty widely used for build automation with pandoc.

It adds only ~200 KB uncompressed, quoth its [alpine package page](https://pkgs.alpinelinux.org/package/edge/main/x86/make).